### PR TITLE
feat: adjust tile width to grid

### DIFF
--- a/src/common/MovieTile/styled.js
+++ b/src/common/MovieTile/styled.js
@@ -11,7 +11,7 @@ export const StyledMovieTile = styled.section`
   background-color: ${({ theme }) => theme.colors.white};
 
   @media (max-width: ${({ theme }) => theme.media.mobile}px) {
-    max-width: 340px;
+    max-width: 350px;
     min-height: 201px;
     grid-template-columns: repeat(2, 1fr);
     gap: 16px;

--- a/src/common/MovieTile/styled.js
+++ b/src/common/MovieTile/styled.js
@@ -3,15 +3,15 @@ import { ReactComponent as StarIcon } from "../../assets/starIcon.svg";
 
 export const StyledMovieTile = styled.section`
   display: grid;
-  max-width: 324px;
+  width: 100%;
+  padding: 16px;
   min-height: 650px;
   border-radius: 5px;
-  padding: 16px;
   grid-template-columns: 1fr;
   background-color: ${({ theme }) => theme.colors.white};
 
   @media (max-width: ${({ theme }) => theme.media.mobile}px) {
-    max-width: 288px;
+    max-width: 340px;
     min-height: 201px;
     grid-template-columns: repeat(2, 1fr);
     gap: 16px;
@@ -19,9 +19,9 @@ export const StyledMovieTile = styled.section`
 `;
 
 export const Image = styled.img`
-  width: 292px;
-  height: 434px;
+  width: 100%;
   border-radius: 5px;
+  margin: 0 auto;
 
   @media (max-width: ${({ theme }) => theme.media.mobile}px) {
     width: 114px;

--- a/src/features/MovieList/styled.js
+++ b/src/features/MovieList/styled.js
@@ -26,7 +26,8 @@ export const StyledList = styled.ul`
   grid-gap: 24px;
 
   @media (max-width: ${({ theme }) => theme.media.mobile}px) {
-    grid-gap: 16px 0;
+    grid-template-columns: repeat(auto-fill, minmax(288px, 1fr));
+    grid-gap: 16px;
   }
 `;
 


### PR DESCRIPTION
I have implemented a feature to align tiles to the grid. This ensures that the spacing between tiles is consistent, thereby enhancing the overall layout presentation.
